### PR TITLE
Add support for offline tokens

### DIFF
--- a/proto/oidc/cfg.go
+++ b/proto/oidc/cfg.go
@@ -1,11 +1,12 @@
 package oidc
 
 type ServerProfile struct {
-	URL      string
-	TokenAPI string
-	AuthAPI  string
-	Form     *HTMLFormConfig
-	Insecure bool
+	URL              string
+	TokenAPI         string
+	AuthAPI          string
+	Form             *HTMLFormConfig
+	Insecure         bool
+	AdditionalScopes []string
 }
 
 // Merge sets any unset field in s from in, and returns the merged copy
@@ -18,6 +19,8 @@ func (s ServerProfile) Merge(in ServerProfile) ServerProfile {
 	if ret.Form == nil {
 		ret.Form = in.Form
 	}
+	ret.AdditionalScopes = append(s.AdditionalScopes, in.AdditionalScopes...)
+
 	return ret
 }
 

--- a/proto/oidc/protocol.go
+++ b/proto/oidc/protocol.go
@@ -146,7 +146,7 @@ func (p *Protocol) GetToken(request proto.TokenRequest) (string, interface{}, er
 	conf := &oauth2.Config{
 		ClientID:     cfg.ClientId,
 		ClientSecret: cfg.ClientSecret,
-		Scopes:       []string{"openid", "offline_access"},
+		Scopes:       []string{"openid"},
 		RedirectURL:  cfg.CallbackURL,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  p.GetAuthURL(),
@@ -156,6 +156,7 @@ func (p *Protocol) GetToken(request proto.TokenRequest) (string, interface{}, er
 	var err error
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, proto.GetHTTPClient())
+	conf.Scopes = append(conf.Scopes, cfg.AdditionalScopes...)
 	if cfg.PasswordGrant {
 		var password string
 		if len(request.Password) > 0 {


### PR DESCRIPTION
We need to request the `offline_access` scope in order for our refresh tokens to not have an expiration.