### PR TITLE
Strip debug symbols for production build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREFIX?=$(shell pwd)
 
 .PHONY: build clean fmt lint test vet
 .DEFAULT: all
-all:  fmt vet lint build test 
+all:  fmt vet lint build test
 
 # Package list
 PKGS=$(shell go list  ./...| grep -v /vendor/)
@@ -18,27 +18,31 @@ vet:
 fmt:
 	@echo "+ $@"
 	@test -z "$$(gofmt -s -l cfg 2>&1 | tee /dev/stderr)" || \
-	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false) 
+	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false)
 	@test -z "$$(gofmt -s -l cmd 2>&1 |  tee /dev/stderr)" || \
-	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false) 
+	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false)
 	@test -z "$$(gofmt -s -l crypta 2>&1 | tee /dev/stderr)" || \
-	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false) 
+	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false)
 	@test -z "$$(gofmt -s -l proto 2>&1 |  tee /dev/stderr)" || \
-	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false) 
+	  (echo >&2 "+ please format Go code with 'gofmt -s'" && false)
 
 
 lint:
 	@echo "+ $@"
-	-$(GOLINT) cfg/... 
-	-$(GOLINT) cmd/... 
-	-$(GOLINT) crypta/... 
-	-$(GOLINT) proto/... 
+	-$(GOLINT) cfg/...
+	-$(GOLINT) cmd/...
+	-$(GOLINT) crypta/...
+	-$(GOLINT) proto/...
 
-build: fmt vet lint 
+build: fmt vet lint
 	@echo "+ $@"
 	@go build
 
-dist: build test
+build-prod: fmt vet lint
+	@echo "+ $@"
+	@go build -ldflags "-s -w"
+
+dist: build-prod test
 	{ \
 	tag=`git tag -l --points-at HEAD`; \
 	if [ ! -z $$tag ] ; then tag="-$$tag";	fi; \


### PR DESCRIPTION
Having a build that's development makes sense, but when going to prod we can save 2+ MB with the debug symbols left out of the build. This pull request does just that. I added a separate make task so that we have both builds available. The dist task build prod though. 