### PR TITLE
Support public OIDC clients

### DIFF
--- a/proto/oidc/cmd.go
+++ b/proto/oidc/cmd.go
@@ -34,9 +34,6 @@ var oidcConnectWizard = []proto.SetupStep{
 	}, GetDefault: func(remoteCfg interface{}) string { return remoteCfg.(*Config).ClientID }},
 	{Prompt: "Client secret:", Parse: func(in string) error {
 		in = strings.TrimSpace(in)
-		if len(in) == 0 {
-			return fmt.Errorf("Client secret is required")
-		}
 		oidcCfg.Cfg.ClientSecret = in
 		return nil
 	}, GetDefault: func(remoteCfg interface{}) string { return remoteCfg.(*Config).ClientSecret }},
@@ -70,8 +67,7 @@ func init() {
 
 		cmd.Flags().StringVarP(&oidcCfg.Cfg.ClientID, "clientId", "c", "", "Client ID (required)")
 		cmd.MarkFlagRequired("clientId")
-		cmd.Flags().StringVarP(&oidcCfg.Cfg.ClientSecret, "secret", "s", "", "Client Secret (required)")
-		cmd.MarkFlagRequired("secret")
+		cmd.Flags().StringVarP(&oidcCfg.Cfg.ClientSecret, "secret", "s", "", "Client Secret")
 		cmd.Flags().StringVarP(&oidcCfg.Cfg.CallbackURL, "callback-url", "b", "", "Callback URL")
 		cmd.Flags().StringVarP(&oidcCfg.Cfg.Profile, "server", "e", "", "Server profile to use. Either a server profile or the server URL must be given")
 		cmd.Flags().StringVarP(&oidcCfg.Cfg.URL, "url", "u", "", "Server URL. Either a server profile or server URL must be given")

--- a/proto/oidc/refresh.go
+++ b/proto/oidc/refresh.go
@@ -15,7 +15,9 @@ import (
 func RefreshToken(clientID, clientSecret, refreshToken, tokenURL string) (oauth2.Token, error) {
 	values := url.Values{}
 	values.Set("client_id", clientID)
-	values.Set("client_secret", clientSecret)
+	if len(clientSecret) > 0 {
+		values.Set("client_secret", clientSecret)
+	}
 	values.Set("refresh_token", refreshToken)
 	values.Set("grant_type", "refresh_token")
 	log.Debugf("Refresh %s %v", tokenURL, values)

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ authorization server based on a known server profile.
  * Assign a name to this authentication configuration
  * You need to enter the following options to create a new authentication configuration:
     * client id
-    * client secret
+    * client secret (not required for public clients)
     * callback url (not required for password grants)
     * whether the client will use password grants or not
 
@@ -76,7 +76,6 @@ method.
 Required options for oidc:
  * -n Name of the configuration. This is the 'myapi' parameter in the above examples
  * -c Client ID
- * -s Client secret
  * -u Server URL, including domain, excluding protocol specific paths
 
 


### PR DESCRIPTION
Not all OIDC clients are confidential, therefore we should not make `secret` a required config item. Additionally, when calling the token endpoint of the IdP, the `client_secret` parameter should be omitted entirely if no client secret is configured.