### PR TITLE
Add support for refresh token flow

### DIFF
--- a/proto/oidc/cfg.go
+++ b/proto/oidc/cfg.go
@@ -8,6 +8,7 @@ type ServerProfile struct {
 	Form             *HTMLFormConfig `yaml:"form,omitempty" mapstructure:"form,omitempty"`
 	Insecure         bool
 	PasswordGrant    *bool    `yaml:"passwordgrant,omitempty"`
+	RefreshOnly      *bool    `yaml:"refreshonly,omitempty"`
 	AdditionalScopes []string `yaml:"additionalscopes,omitempty"`
 }
 
@@ -20,6 +21,10 @@ func (s ServerProfile) Merge(in ServerProfile) ServerProfile {
 	ret.PasswordGrant = s.PasswordGrant
 	if ret.PasswordGrant == nil {
 		ret.PasswordGrant = in.PasswordGrant
+	}
+	ret.RefreshOnly = s.RefreshOnly
+	if ret.RefreshOnly == nil {
+		ret.RefreshOnly = in.RefreshOnly
 	}
 	ret.Form = s.Form
 	if ret.Form == nil {

--- a/readme.md
+++ b/readme.md
@@ -97,11 +97,22 @@ Took supports direct access grants. In this flow, took asks username and passwor
 them to the authentication server.
 
 ```
-  took add oidc -n prod-direct -c 12345 -s abcdef -u https://myserver/realms/myrealm -p
+  took add oidc -n prod-direct -c 12345 -s abcdef -u https://myserver/realms/myrealm -f pwd
 ```
 To use this, the authentication server must be configured to support 
 direct access grants flow for this client.
 
+## Refresh Token Flow
+
+Took supports using only refresh token grants. In this flow, took asks for a refresh token
+to send to the authentication server. This is commonly used in conjunction with
+offline refresh tokens.
+
+```
+  took add oidc -n prod-refresh -c 12345 -u https://myserver/realms/myrealm -f refresh
+```
+To use this, you must already have obtained a refresh token via some other means
+(usually from a web portal).
 
 # Multiple users 
 


### PR DESCRIPTION
This PR enhances `took` to support using offline/refresh tokens exclusively. In this flow, the user provides `took` with a refresh token, which it then uses to uses for a refresh grant at the IdP's `/token` endpoint. Should the refresh token expire or otherwise become invalidated, the user is prompted for a new refresh token.

This flow enables a use-case for us as we are shifting away from using direct access grants. Instead of creating their own client credentials and using direct access grants, users now obtain an offline token via a web portal for a shared public client. The user then simply uses that offline token to obtain access tokens as needed without needing to provide username/password credentials again.